### PR TITLE
prevent crash if "o:get_luaentity()" returns nil

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -43,7 +43,7 @@ end
 local clearscreen = function(pos)
     local objects = minetest.get_objects_inside_radius(pos, 0.5)
     for _, o in ipairs(objects) do
-        if o:get_luaentity().name == "textline:text" then
+        if o:get_luaentity() and o:get_luaentity().name == "textline:text" then
             o:remove()
         end
     end


### PR DESCRIPTION
related issue: https://github.com/pandorabox-io/pandorabox.io/issues/487